### PR TITLE
Fix compatibility patch errors

### DIFF
--- a/ModPatches/Combat Extended/Patches/Combat Extended/Bodies/Pegasus_Bodytype.xml
+++ b/ModPatches/Combat Extended/Patches/Combat Extended/Bodies/Pegasus_Bodytype.xml
@@ -37,13 +37,13 @@
 					</value>
 				</li>
 				<li Class="PatchOperationAdd">
-					<xpath>Defs/BodyDef[defName="Pegasus"]/corePart/parts/li[def="Left_Pony_Wing"]/groups</xpath>
+					<xpath>Defs/BodyDef[defName="Pegasus"]/corePart/parts/li[def="Pony_LeftWing"]/groups</xpath>
 					<value>
 						<li>CoveredByNaturalArmor</li>
 					</value>
 				</li>
 				<li Class="PatchOperationAdd">
-					<xpath>Defs/BodyDef[defName="Pegasus"]/corePart/parts/li[def="Right_Pony_Wing"]/groups</xpath>
+					<xpath>Defs/BodyDef[defName="Pegasus"]/corePart/parts/li[def="Pony_RightWing"]/groups</xpath>
 					<value>
 						<li>CoveredByNaturalArmor</li>
 					</value>

--- a/ModPatches/Expanded Prosthetics and Organ Engineering - Forked/Patches/Expanded Prosthetics and Organ Engineering - Forked/HediffDefs/HediffDefs_OrganicOptimizer.xml
+++ b/ModPatches/Expanded Prosthetics and Organ Engineering - Forked/Patches/Expanded Prosthetics and Organ Engineering - Forked/HediffDefs/HediffDefs_OrganicOptimizer.xml
@@ -5,8 +5,8 @@
 		<match Class="PatchOperationAdd">
 			<xpath>Defs/RecipeDef[defName="EPOE_OrganicOptimizing"]/appliedOnFixedBodyParts</xpath>
 			<value>
-				<li>Left_Pony_Wing</li>
-				<li>Right_Pony_Wing</li>
+				<li>Pony_LeftWing</li>
+				<li>Pony_RightWing</li>
 				<li>Pony_Horn</li>
 			</value>
 		</match>

--- a/ModPatches/Expanded Prosthetics and Organ Engineering - Forked/Patches/Expanded Prosthetics and Organ Engineering - Forked/HediffDefs/HediffDefs_SimpleProsthetics.xml
+++ b/ModPatches/Expanded Prosthetics and Organ Engineering - Forked/Patches/Expanded Prosthetics and Organ Engineering - Forked/HediffDefs/HediffDefs_SimpleProsthetics.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Patch>
-
 	<Operation Class="PatchOperationConditional">
 		<xpath>Defs/HediffDef[defName="SimpleProstheticHand"]/comps</xpath>
 		<match Class="PatchOperationAdd">

--- a/ModPatches/Expanded Prosthetics and Organ Engineering - Forked/Patches/Expanded Prosthetics and Organ Engineering - Forked/HediffDefs/HediffDefs_SimpleProsthetics.xml
+++ b/ModPatches/Expanded Prosthetics and Organ Engineering - Forked/Patches/Expanded Prosthetics and Organ Engineering - Forked/HediffDefs/HediffDefs_SimpleProsthetics.xml
@@ -1,37 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Patch>
-	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/HediffDef[defName="SimpleProstheticArm"]/comps</xpath>
-		<match Class="PatchOperationAdd">
-			<xpath>Defs/HediffDef[defName="SimpleProstheticArm"]/comps</xpath>
-			<value>
-				<li Class="PoniesOfTheRim.HediffCompProperties_PonyProsthetic">
-					<prefix>Modified</prefix>
-					<inBrackets>Pony</inBrackets>
-					<!-- <descriptionExtra>pon</descriptionExtra> -->
-					<tipStringExtra>This humanoid prosthesis is modified to match the anatomy of a pony.</tipStringExtra>
-				</li>
-			</value>
-		</match>
-	</Operation>
-	
-	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/HediffDef[defName="SimpleProstheticLeg"]</xpath>
-		<match Class="PatchOperationAdd">
-			<xpath>Defs/HediffDef[defName="SimpleProstheticLeg"]</xpath>
-			<value>
-				<comps>
-					<li Class="PoniesOfTheRim.HediffCompProperties_PonyProsthetic">
-						<prefix>Modified</prefix>
-						<inBrackets>Pony</inBrackets>
-						<!-- <descriptionExtra>pon</descriptionExtra> -->
-						<tipStringExtra>This humanoid prosthesis is modified to match the anatomy of a pony.</tipStringExtra>
-					</li>
-				</comps>
-			</value>
-		</match>
-	</Operation>
-	
+
 	<Operation Class="PatchOperationConditional">
 		<xpath>Defs/HediffDef[defName="SimpleProstheticHand"]/comps</xpath>
 		<match Class="PatchOperationAdd">
@@ -46,7 +15,7 @@
 			</value>
 		</match>
 	</Operation>
-	
+
 	<Operation Class="PatchOperationConditional">
 		<xpath>Defs/HediffDef[defName="SimpleProstheticFoot"]</xpath>
 		<match Class="PatchOperationAdd">
@@ -63,7 +32,7 @@
 			</value>
 		</match>
 	</Operation>
-	
+
 	<Operation Class="PatchOperationConditional">
 		<xpath>Defs/HediffDef[defName="EPOE_ScytherBlade"]/comps</xpath>
 		<match Class="PatchOperationAdd">

--- a/ModPatches/RBSE/Patches/RBSE/HediffDefs/HediffDefs_SimpleProsthetics.xml
+++ b/ModPatches/RBSE/Patches/RBSE/HediffDefs/HediffDefs_SimpleProsthetics.xml
@@ -16,7 +16,7 @@
 			</value>
 		</match>
 	</Operation>
-	
+
 	<Operation Class="PatchOperationConditional">
 		<xpath>Defs/HediffDef[defName="WoodenFoot"]</xpath>
 		<match Class="PatchOperationAdd">
@@ -33,39 +33,7 @@
 			</value>
 		</match>
 	</Operation>
-	
-	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/HediffDef[defName="SimpleProstheticLeg"]</xpath>
-		<match Class="PatchOperationAdd">
-			<xpath>Defs/HediffDef[defName="SimpleProstheticLeg"]</xpath>
-			<value>
-				<comps>
-					<li Class="PoniesOfTheRim.HediffCompProperties_PonyProsthetic">
-						<prefix>Modified</prefix>
-						<inBrackets>Pony</inBrackets>
-						<!-- <descriptionExtra>pon</descriptionExtra> -->
-						<tipStringExtra>This humanoid prosthesis is modified to match the anatomy of a pony.</tipStringExtra>
-					</li>
-				</comps>
-			</value>
-		</match>
-	</Operation>
-	
-	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/HediffDef[defName="SimpleProstheticArm"]/comps</xpath>
-		<match Class="PatchOperationAdd">
-			<xpath>Defs/HediffDef[defName="SimpleProstheticArm"]/comps</xpath>
-			<value>
-				<li Class="PoniesOfTheRim.HediffCompProperties_PonyProsthetic">
-					<prefix>Modified</prefix>
-					<inBrackets>Pony</inBrackets>
-					<!-- <descriptionExtra>pon</descriptionExtra> -->
-					<tipStringExtra>This humanoid prosthesis is modified to match the anatomy of a pony.</tipStringExtra>
-				</li>
-			</value>
-		</match>
-	</Operation>
-	
+
 	<Operation Class="PatchOperationConditional">
 		<xpath>Defs/HediffDef[defName="HookHand"]/comps</xpath>
 		<match Class="PatchOperationAdd">
@@ -80,7 +48,7 @@
 			</value>
 		</match>
 	</Operation>
-	
+
 	<Operation Class="PatchOperationConditional">
 		<xpath>Defs/HediffDef[defName="SimpleProstheticHand"]/comps</xpath>
 		<match Class="PatchOperationAdd">
@@ -95,7 +63,7 @@
 			</value>
 		</match>
 	</Operation>
-	
+
 	<Operation Class="PatchOperationConditional">
 		<xpath>Defs/HediffDef[defName="SimpleProstheticFoot"]</xpath>
 		<match Class="PatchOperationAdd">


### PR DESCRIPTION
There are a few issues with the compatibility patches that cause red errors on startup when using the other mods.

- A few references to the pony wing defs used the wrong def names.
- The `SimpleProstheticArm` and `SimpleProstheticLeg` patches already exist in the core patches. Adding them again in the compatibility patches causes a config error due to the duplicate XML node.

<img width="881" alt="2025-03-23_04-02-12" src="https://github.com/user-attachments/assets/d19566c0-cc8d-4a70-b06d-0a6126c6e989" />
