### PR TITLE
Improve Core mod Combat Extended Patches

### DIFF
--- a/Ponies of the Rim-Core/1.6/ModPatches/Combat Extended/Patches/Scenarios/Scenarios_Pony.xml
+++ b/Ponies of the Rim-Core/1.6/ModPatches/Combat Extended/Patches/Scenarios/Scenarios_Pony.xml
@@ -26,9 +26,6 @@
 						</li>
 					</value>
 				</li>
-				<li Class="PatchOperationRemove">
-					<xpath>Defs/ThingDef[defName="Apparel_AdvancedHelmet"]/stuffCategories</xpath>
-				</li>
 				<li Class="PatchOperationAdd">
 					<xpath>Defs/FactionDef[defName="PonyColony"]/apparelStuffFilter/thingDefs</xpath>
 					<value>

--- a/Ponies of the Rim-Core/1.6/ModPatches/Combat Extended/Patches/Scenarios/Scenarios_Pony.xml
+++ b/Ponies of the Rim-Core/1.6/ModPatches/Combat Extended/Patches/Scenarios/Scenarios_Pony.xml
@@ -1,12 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Patch>
-
-
-	<Operation Class="PatchOperationRemove">
-		<xpath>Defs/ThingDef[defName="Apparel_AdvancedHelmet"]/stuffCategories</xpath>
-	</Operation>
-
-
 	<Operation Class="PatchOperationFindMod">
 		<mods>
 			<li>Combat Extended</li>
@@ -32,6 +25,9 @@
 							<count>150</count>
 						</li>
 					</value>
+				</li>
+				<li Class="PatchOperationRemove">
+					<xpath>Defs/ThingDef[defName="Apparel_AdvancedHelmet"]/stuffCategories</xpath>
 				</li>
 				<li Class="PatchOperationAdd">
 					<xpath>Defs/FactionDef[defName="PonyColony"]/apparelStuffFilter/thingDefs</xpath>

--- a/Ponies of the Rim-Core/1.6/ModPatches/Combat Extended/Patches/ThingDefs_Items/Apparel_Utility.xml
+++ b/Ponies of the Rim-Core/1.6/ModPatches/Combat Extended/Patches/ThingDefs_Items/Apparel_Utility.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Combat Extended</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+				<!-- == Saddlebag == -->
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="Pony_SaddleBag"]/statBases</xpath>
+					<value>
+						<Bulk>3</Bulk>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="Pony_SaddleBag"]/equippedStatOffsets</xpath>
+					<value>
+						<equippedStatOffsets>
+							<CarryBulk>40</CarryBulk>
+						</equippedStatOffsets>
+					</value>
+				</li>
+
+				<!-- Note: Changing the layer and body part coverage modified like below cause 
+					the saddlebags to either not render at all or render as a shirt. -->
+				<!-- <li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="Pony_SaddleBag"]/apparel/bodyPartGroups</xpath>
+					<value>
+						<bodyPartGroups>
+							<li>Torso</li>
+						</bodyPartGroups>
+					</value>
+				</li>
+				
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="Pony_SaddleBag"]/apparel/layers</xpath>
+					<value>
+						<layers>
+							<li>Webbing</li>
+						</layers>
+					</value>
+				</li> -->
+
+				<!-- == Battle Saddle == -->
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="Pony_BattleSaddle"]/statBases</xpath>
+					<value>
+						<Bulk>3</Bulk>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="Pony_BattleSaddle"]/equippedStatOffsets</xpath>
+					<value>
+						<equippedStatOffsets>
+							<AimingDelayFactor>-0.15</AimingDelayFactor>
+							<CarryBulk>20</CarryBulk> <!-- Enough to carry something like an assault rifle. -->
+						</equippedStatOffsets>
+					</value>
+				</li>
+
+				<!-- Layer and body part coverage are unchanged. -->
+
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/Ponies of the Rim-Core/1.6/ModPatches/Combat Extended/Patches/ThingDefs_Items/Items_Ponyfur.xml
+++ b/Ponies of the Rim-Core/1.6/ModPatches/Combat Extended/Patches/ThingDefs_Items/Items_Ponyfur.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Patch>
+    <Operation Class="PatchOperationReplace">
+        <xpath>Defs/ThingDef[defName="PonyFur"]/statBases/StuffPower_Armor_Sharp</xpath>
+        <value>
+            <StuffPower_Armor_Sharp>0.036</StuffPower_Armor_Sharp>
+        </value>
+    </Operation>
+    <Operation Class="PatchOperationReplace">
+        <xpath>Defs/ThingDef[defName="PonyFur"]/statBases/StuffPower_Armor_Blunt</xpath>
+        <value>
+            <StuffPower_Armor_Blunt>0.04</StuffPower_Armor_Blunt>
+        </value>
+    </Operation>
+</Patch>

--- a/Ponies of the Rim-Core/1.6/ModPatches/Combat Extended/Patches/ThingDefs_Races/Race_BasePony.xml
+++ b/Ponies of the Rim-Core/1.6/ModPatches/Combat Extended/Patches/ThingDefs_Races/Race_BasePony.xml
@@ -10,15 +10,13 @@
 					<xpath>Defs/AlienRace.ThingDef_AlienRace[@Name="BasePony"]/comps</xpath>
 					<value>
 						<li Class="CombatExtended.CompProperties_Inventory"/>
-					</value>
-				</li>
-				<li Class="PatchOperationAdd">
-					<xpath>Defs/AlienRace.ThingDef_AlienRace[@Name="BasePony"]/comps</xpath>
-					<value>
 						<li>
 							<compClass>CombatExtended.CompPawnGizmo</compClass>
 						</li>
 						<li Class="CombatExtended.CompProperties_Suppressable"/>
+						<li>
+							<compClass>CombatExtended.CompAmmoGiver</compClass>
+						</li>
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">

--- a/Ponies of the Rim-Core/1.6/ModPatches/Combat Extended/Patches/ThingDefs_Races/Race_Earthpony.xml
+++ b/Ponies of the Rim-Core/1.6/ModPatches/Combat Extended/Patches/ThingDefs_Races/Race_Earthpony.xml
@@ -30,8 +30,10 @@
 				<li Class="PatchOperationAdd">
 					<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Pony_Earthpony"]/statBases</xpath>
 					<value>
+						<!-- For some reason, this doesn't work. -->
 						<MeleeCritChance>1.55</MeleeCritChance>
 						<MeleeParryChance>1.25</MeleeParryChance>
+						<MeleeDodgeChance>1</MeleeDodgeChance>
 						<Suppressability>0.6</Suppressability>
 						<SmokeSensitivity>0.2</SmokeSensitivity>
 						<NightVisionEfficiency>0.4</NightVisionEfficiency>

--- a/Ponies of the Rim-Core/1.6/ModPatches/Combat Extended/Patches/ThingDefs_Races/Race_Earthpony.xml
+++ b/Ponies of the Rim-Core/1.6/ModPatches/Combat Extended/Patches/ThingDefs_Races/Race_Earthpony.xml
@@ -1,47 +1,38 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Patch>
-	<Operation Class="PatchOperationFindMod">
-		<mods>
-			<li>Combat Extended</li>
-		</mods>
-		<match Class="PatchOperationSequence">
-			<operations>
-				<li Class="PatchOperationConditional">
-					<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Pony_Earthpony"]/comps</xpath>
-					<nomatch Class="PatchOperationAdd">
-						<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Pony_Earthpony"]</xpath>
-						<value>
-							<comps/>
-						</value>
-					</nomatch>
-					<match Class="PatchOperationAdd">
-						<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Pony_Earthpony"]</xpath>
-						<value/>
-					</match>
-				</li>
-				<li Class="PatchOperationAddModExtension">
-					<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Pony_Earthpony"]</xpath>
-					<value>
-						<li Class="CombatExtended.RacePropertiesExtensionCE">
-							<bodyShape>Quadruped</bodyShape>
-						</li>
-					</value>
-				</li>
-				<li Class="PatchOperationAdd">
-					<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Pony_Earthpony"]/statBases</xpath>
-					<value>
-						<!-- For some reason, this doesn't work. -->
-						<MeleeCritChance>1.55</MeleeCritChance>
-						<MeleeParryChance>1.25</MeleeParryChance>
-						<MeleeDodgeChance>1</MeleeDodgeChance>
-						<Suppressability>0.6</Suppressability>
-						<SmokeSensitivity>0.2</SmokeSensitivity>
-						<NightVisionEfficiency>0.4</NightVisionEfficiency>
-						<CarryBulk>30</CarryBulk>
-						<CarryWeight>60</CarryWeight>
-					</value>
-				</li>
-			</operations>
+	<Operation Class="PatchOperationConditional">
+		<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Pony_Earthpony"]/comps</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Pony_Earthpony"]</xpath>
+			<value>
+				<comps />
+			</value>
+		</nomatch>
+		<match Class="PatchOperationAdd">
+			<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Pony_Earthpony"]</xpath>
+			<value />
 		</match>
+	</Operation>
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Pony_Earthpony"]</xpath>
+		<value>
+			<li Class="CombatExtended.RacePropertiesExtensionCE">
+				<bodyShape>Quadruped</bodyShape>
+			</li>
+		</value>
+	</Operation>
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Pony_Earthpony"]/statBases</xpath>
+		<value>
+			<!-- For some reason, this doesn't work. -->
+			<MeleeCritChance>1.55</MeleeCritChance>
+			<MeleeParryChance>1.25</MeleeParryChance>
+			<MeleeDodgeChance>1</MeleeDodgeChance>
+			<Suppressability>0.6</Suppressability>
+			<SmokeSensitivity>0.2</SmokeSensitivity>
+			<NightVisionEfficiency>0.4</NightVisionEfficiency>
+			<CarryBulk>30</CarryBulk>
+			<CarryWeight>60</CarryWeight>
+		</value>
 	</Operation>
 </Patch>

--- a/Ponies of the Rim-Core/1.6/ModPatches/Combat Extended/Patches/ThingDefs_Races/Race_Pegasus.xml
+++ b/Ponies of the Rim-Core/1.6/ModPatches/Combat Extended/Patches/ThingDefs_Races/Race_Pegasus.xml
@@ -30,8 +30,10 @@
 				<li Class="PatchOperationAdd">
 					<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Pony_Pegasus"]/statBases</xpath>
 					<value>
+						<!-- For some reason, this doesn't work. -->
 						<MeleeCritChance>1.55</MeleeCritChance>
 						<MeleeParryChance>1.25</MeleeParryChance>
+						<MeleeDodgeChance>1</MeleeDodgeChance>
 						<Suppressability>0.6</Suppressability>
 						<SmokeSensitivity>0.2</SmokeSensitivity>
 						<NightVisionEfficiency>0.4</NightVisionEfficiency>

--- a/Ponies of the Rim-Core/1.6/ModPatches/Combat Extended/Patches/ThingDefs_Races/Race_Pegasus.xml
+++ b/Ponies of the Rim-Core/1.6/ModPatches/Combat Extended/Patches/ThingDefs_Races/Race_Pegasus.xml
@@ -1,47 +1,38 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Patch>
-	<Operation Class="PatchOperationFindMod">
-		<mods>
-			<li>Combat Extended</li>
-		</mods>
-		<match Class="PatchOperationSequence">
-			<operations>
-				<li Class="PatchOperationConditional">
-					<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Pony_Pegasus"]/comps</xpath>
-					<nomatch Class="PatchOperationAdd">
-						<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Pony_Pegasus"]</xpath>
-						<value>
-							<comps/>
-						</value>
-					</nomatch>
-					<match Class="PatchOperationAdd">
-						<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Pony_Pegasus"]</xpath>
-						<value/>
-					</match>
-				</li>
-				<li Class="PatchOperationAddModExtension">
-					<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Pony_Pegasus"]</xpath>
-					<value>
-						<li Class="CombatExtended.RacePropertiesExtensionCE">
-							<bodyShape>Quadruped</bodyShape>
-						</li>
-					</value>
-				</li>
-				<li Class="PatchOperationAdd">
-					<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Pony_Pegasus"]/statBases</xpath>
-					<value>
-						<!-- For some reason, this doesn't work. -->
-						<MeleeCritChance>1.55</MeleeCritChance>
-						<MeleeParryChance>1.25</MeleeParryChance>
-						<MeleeDodgeChance>1</MeleeDodgeChance>
-						<Suppressability>0.6</Suppressability>
-						<SmokeSensitivity>0.2</SmokeSensitivity>
-						<NightVisionEfficiency>0.4</NightVisionEfficiency>
-						<CarryBulk>30</CarryBulk>
-						<CarryWeight>60</CarryWeight>
-					</value>
-				</li>
-			</operations>
+	<Operation Class="PatchOperationConditional">
+		<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Pony_Pegasus"]/comps</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Pony_Pegasus"]</xpath>
+			<value>
+				<comps />
+			</value>
+		</nomatch>
+		<match Class="PatchOperationAdd">
+			<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Pony_Pegasus"]</xpath>
+			<value />
 		</match>
+	</Operation>
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Pony_Pegasus"]</xpath>
+		<value>
+			<li Class="CombatExtended.RacePropertiesExtensionCE">
+				<bodyShape>Quadruped</bodyShape>
+			</li>
+		</value>
+	</Operation>
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Pony_Pegasus"]/statBases</xpath>
+		<value>
+			<!-- For some reason, this doesn't work. -->
+			<MeleeCritChance>1.55</MeleeCritChance>
+			<MeleeParryChance>1.25</MeleeParryChance>
+			<MeleeDodgeChance>1</MeleeDodgeChance>
+			<Suppressability>0.6</Suppressability>
+			<SmokeSensitivity>0.2</SmokeSensitivity>
+			<NightVisionEfficiency>0.4</NightVisionEfficiency>
+			<CarryBulk>30</CarryBulk>
+			<CarryWeight>60</CarryWeight>
+		</value>
 	</Operation>
 </Patch>

--- a/Ponies of the Rim-Core/1.6/ModPatches/Combat Extended/Patches/ThingDefs_Races/Race_Unicorn.xml
+++ b/Ponies of the Rim-Core/1.6/ModPatches/Combat Extended/Patches/ThingDefs_Races/Race_Unicorn.xml
@@ -30,8 +30,10 @@
 				<li Class="PatchOperationAdd">
 					<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Pony_Unicorn"]/statBases</xpath>
 					<value>
+						<!-- For some reason, this doesn't work. -->
 						<MeleeCritChance>1.55</MeleeCritChance>
 						<MeleeParryChance>1.25</MeleeParryChance>
+						<MeleeDodgeChance>1</MeleeDodgeChance>
 						<Suppressability>0.6</Suppressability>
 						<SmokeSensitivity>0.2</SmokeSensitivity>
 						<NightVisionEfficiency>0.4</NightVisionEfficiency>

--- a/Ponies of the Rim-Core/1.6/ModPatches/Combat Extended/Patches/ThingDefs_Races/Race_Unicorn.xml
+++ b/Ponies of the Rim-Core/1.6/ModPatches/Combat Extended/Patches/ThingDefs_Races/Race_Unicorn.xml
@@ -1,65 +1,56 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Patch>
-	<Operation Class="PatchOperationFindMod">
-		<mods>
-			<li>Combat Extended</li>
-		</mods>
-		<match Class="PatchOperationSequence">
-			<operations>
-				<li Class="PatchOperationConditional">
-					<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Pony_Unicorn"]/comps</xpath>
-					<nomatch Class="PatchOperationAdd">
-						<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Pony_Unicorn"]</xpath>
-						<value>
-							<comps/>
-						</value>
-					</nomatch>
-					<match Class="PatchOperationAdd">
-						<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Pony_Unicorn"]</xpath>
-						<value/>
-					</match>
-				</li>
-				<li Class="PatchOperationAddModExtension">
-					<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Pony_Unicorn"]</xpath>
-					<value>
-						<li Class="CombatExtended.RacePropertiesExtensionCE">
-							<bodyShape>Quadruped</bodyShape>
-						</li>
-					</value>
-				</li>
-				<li Class="PatchOperationAdd">
-					<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Pony_Unicorn"]/statBases</xpath>
-					<value>
-						<!-- For some reason, this doesn't work. -->
-						<MeleeCritChance>1.55</MeleeCritChance>
-						<MeleeParryChance>1.25</MeleeParryChance>
-						<MeleeDodgeChance>1</MeleeDodgeChance>
-						<Suppressability>0.6</Suppressability>
-						<SmokeSensitivity>0.2</SmokeSensitivity>
-						<NightVisionEfficiency>0.4</NightVisionEfficiency>
-						<CarryBulk>30</CarryBulk>
-						<CarryWeight>60</CarryWeight>
-					</value>
-				</li>
-				<li Class="PatchOperationReplace">
-					<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Pony_Unicorn"]/tools</xpath>
-					<value>
-						<tools>
-							<li Class="CombatExtended.ToolCE">
-								<label>horn</label>
-								<capacities>
-									<li>Poke</li>
-								</capacities>
-								<power>8.2</power>
-								<cooldownTime>2</cooldownTime>
-								<linkedBodyPartsGroup>Horn</linkedBodyPartsGroup>
-								<chanceFactor>0.2</chanceFactor>
-								<armorPenetrationSharp>0.3</armorPenetrationSharp>
-							</li>
-						</tools>
-					</value>
-				</li>
-			</operations>
+	<Operation Class="PatchOperationConditional">
+		<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Pony_Unicorn"]/comps</xpath>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Pony_Unicorn"]</xpath>
+			<value>
+				<comps />
+			</value>
+		</nomatch>
+		<match Class="PatchOperationAdd">
+			<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Pony_Unicorn"]</xpath>
+			<value />
 		</match>
+	</Operation>
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Pony_Unicorn"]</xpath>
+		<value>
+			<li Class="CombatExtended.RacePropertiesExtensionCE">
+				<bodyShape>Quadruped</bodyShape>
+			</li>
+		</value>
+	</Operation>
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Pony_Unicorn"]/statBases</xpath>
+		<value>
+			<!-- For some reason, this doesn't work. -->
+			<MeleeCritChance>1.55</MeleeCritChance>
+			<MeleeParryChance>1.25</MeleeParryChance>
+			<MeleeDodgeChance>1</MeleeDodgeChance>
+			<Suppressability>0.6</Suppressability>
+			<SmokeSensitivity>0.2</SmokeSensitivity>
+			<NightVisionEfficiency>0.4</NightVisionEfficiency>
+			<CarryBulk>30</CarryBulk>
+			<CarryWeight>60</CarryWeight>
+		</value>
+	</Operation>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Pony_Unicorn"]/tools</xpath>
+		<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<label>horn</label>
+					<capacities>
+						<li>Poke</li>
+					</capacities>
+					<power>8.2</power>
+					<cooldownTime>2</cooldownTime>
+					<linkedBodyPartsGroup>Horn</linkedBodyPartsGroup>
+					<chanceFactor>0.2</chanceFactor>
+					<armorPenetrationSharp>0.3</armorPenetrationSharp>
+				</li>
+			</tools>
+		</value>
 	</Operation>
 </Patch>


### PR DESCRIPTION
Adds compatibility for items that were overlooked and makes a few extra changes to the pony and scenario patches. ~~Still work in progress.~~ About as finished as I can make it be.

### What This Does
- Patches Pony Fur to have appropriate armor values
- Patches Saddle Bags and Battle Saddles to give Bulk Capacity rather than Carrying Capacity, as is CE balancing standard
- Gives Ponies a base melee dodge chance

### TODOs
- [ ] Fix CE pony stats not working
- [x] Test Unicorn Magic Burst
- [x] Test other misc changes